### PR TITLE
Revival

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ POSTCOMPILE = mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d
 
 ## Linker flags
 LDFLAGS = $(COMMON)
-LDFLAGS += -Wl,--gc-sections -Wl,--relax
+LDFLAGS += -Wl,--gc-sections
 #LDFLAGS += -Wl,-Map=nrf_comm.map
 
 #when the RELAX is activated, it will stop working

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CFLAGS = $(COMMON)
 CFLAGS += -Wall -g0 -gdwarf-2 -DF_CPU=16000000UL -Os
 CFLAGS += -ffreestanding
 CFLAGS += -fno-tree-scev-cprop
-CFLAGS += -mcall-prologues 
+CFLAGS += -mcall-prologues
 CFLAGS += -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -fno-jump-tables
 CFLAGS += -fdata-sections -ffunction-sections 
 CFLAGS += -fno-split-wide-types
@@ -46,7 +46,7 @@ LDFLAGS += -Wl,--gc-sections
 #LDFLAGS += -Wl,-Map=nrf_comm.map
 
 #when the RELAX is activated, it will stop working
-#LDFLAGS_NODE += -Wl,--relax
+LDFLAGS += -Wl,--relax
 LDFLAGS_MASTER = -Wl,-u,vfprintf
 
 ## Objects explicitly added by the user
@@ -105,7 +105,8 @@ mazec:
 
 mazec2:
 	$(CC) $(INCLUDES) $(CFLAGS) -fwhole-program -flto $(LDFLAGS) $(LDFLAGS_MASTER) $(LIBDIRS) $(filter-out nrf_comm.c,$(SRCS)) $(LIBS) -o $(OUTDIR)/$(TARGET_MASTER)
-	$(MAKE) nrf_comm_master.hex
+	$(CESTA)avr-objcopy -O ihex $(HEX_FLASH_FLAGS)  $(OUTDIR)/$(TARGET_MASTER) $(OUTDIR)/nrf_comm_master.hex
+	$(CESTA)avr-size --mcu=$(MCU) --format=avr $(OUTDIR)/$(TARGET_MASTER)
 
 ##Link
 $(TARGET): $(OBJ_PATH)

--- a/Mirf.cpp
+++ b/Mirf.cpp
@@ -48,7 +48,7 @@ void Nrf24l::handleRxLoop(void)
 			  //last_addr_in = pendingPacket.txAddr;
 			  //last_packetCounter_in = pendingPacket.counter;
 
-			  memcpy((void*)(&(rxQueue[rxPosEnd])), (mirfPacket*)&pendingPacket, NRF_PAYLOAD_SIZE);
+			  memcpy((void*)&rxQueue[rxPosEnd], (mirfPacket*)&pendingPacket, NRF_PAYLOAD_SIZE);
 			  inPacketReady++;
 			  rxPosEnd++;
 			  if (rxPosEnd == MAX_RX_PACKET_QUEUE) rxPosEnd = 0; //queue counted from 0, so on the max  number we are already out of array bounds
@@ -75,14 +75,14 @@ void Nrf24l::handleTxLoop(void) //probably should be run from main program loop,
 	  {
 		if ( (ackQueueSize > 0) )
 		{
-			pPaket = (uint8_t *)(&(ackQueue[ackPosBeg]));
+			pPaket = (uint8_t *)&ackQueue[ackPosBeg];
 			whatToSend = 1;
 		}
 		else
 		{
 		   if ( ((SENDING_STATUS)sendingStatus == IN_FIFO) || (sendingStatus == WAIT_FREE_AIR) ) //new packet in fifo waiting to be sent
 		   {
-			   pPaket = (uint8_t *)(&(txQueue[txPosBeg]));
+			   pPaket = (uint8_t *)&txQueue[txPosBeg];
 			   whatToSend = 2;
 		   }
 		}
@@ -184,7 +184,7 @@ void Nrf24l::readPacket(mirfPacket* paket)
 	//we have to temporarily disable timer0 interrupt because no one else could be able to touch
 	//the packet queue until we are finished
   	cli();
-    memcpy(paket, (void*)(&(rxQueue[rxPosBeg])), NRF_PAYLOAD_SIZE);
+    memcpy(paket, (const void*)&rxQueue[rxPosBeg], NRF_PAYLOAD_SIZE);
     inPacketReady--;
     rxPosBeg++;
     if (rxPosBeg == MAX_RX_PACKET_QUEUE) rxPosBeg = 0; //rxPos could wrap.. and we are going anti clockwise
@@ -209,7 +209,7 @@ uint8_t Nrf24l::sendPacket(mirfPacket* paket)
   paket->counter = packetCounter;
   paket->txAddr = devAddr;
 
-  memcpy((void *)&(txQueue[txPosEnd]), (const void *)paket, NRF_PAYLOAD_SIZE);
+  memcpy((void*)&txQueue[txPosEnd], paket, NRF_PAYLOAD_SIZE);
 
   txQueueSize++;
   txPosEnd++;

--- a/Mirf.cpp
+++ b/Mirf.cpp
@@ -326,10 +326,10 @@ void Nrf24l::setDevAddr(ADDR_TYPE addr)
 void Nrf24l::setADDR(void)
 //sets address for RX and TX in NRF module (both the same)
 {
-	ceLow();
+	//ceLow();
 	writeRegister(RX_ADDR_P0, (uint8_t*)mirf_ADDR, mirf_ADDR_LEN);
 	writeRegister(TX_ADDR, (uint8_t*)mirf_ADDR, mirf_ADDR_LEN);  
-	ceHi();
+	//ceHi();
 } 
 
 bool Nrf24l::dataReady() 
@@ -371,7 +371,9 @@ void Nrf24l::getData(uint8_t * data)
 	//  repeat from step 1)."
 	// So if we're going to clear RX_DR here, we need to check the RX FIFO
 	// in the dataReady() function
-	configRegister(STATUS, _BV(RX_DR));   // Reset status register
+
+	//maybe this is not necessary here
+	//configRegister(STATUS, _BV(RX_DR));   // Reset status register
 }
 
 void Nrf24l::configRegister(uint8_t reg, uint8_t value)

--- a/Mirf.h
+++ b/Mirf.h
@@ -8,6 +8,7 @@
 #include <avr/interrupt.h>
 #include "spilib.h"
 #include "packet_defs.h"
+#include "Mirf_nRF24L01.h"
 
 // Nrf24l settings
 
@@ -90,8 +91,8 @@ class Nrf24l {
 	void powerUpTx();
 	void powerDown();
 
-	void nrfSpiWrite(uint8_t reg, uint8_t *data = 0, bool readData = false, uint8_t len = 0);
-	void nrfSpiWrite2(uint8_t reg, uint8_t *data = 0, bool readData = false, uint8_t len = 0);
+	void nrfSpiWrite(uint8_t reg, uint8_t *data = NULL, bool readData = false, uint8_t len = 0);
+	void nrfSpiWrite2(uint8_t reg, uint8_t *data = NULL, bool readData = false, uint8_t len = 0);
 
 	void csnHi(); //__attribute__((noinline))
 	void csnLow();

--- a/Mirf_nRF24L01.h
+++ b/Mirf_nRF24L01.h
@@ -24,6 +24,9 @@
     $Id$
 */
 
+#ifndef _MIRF_COMMANDS_H_
+#define _MIRF_COMMANDS_H_
+
 /* Memory Map */
 #define CONFIG      0x00
 #define EN_AA       0x01
@@ -114,3 +117,5 @@
 #define FLUSH_RX      0xE2
 #define REUSE_TX_PL   0xE3
 #define NOP_CMD       0xFF
+
+#endif //_MIRF_COMMANDS_H_

--- a/out2/upl.sh
+++ b/out2/upl.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-avrdude -patmega328p -carduino -P/dev/tty.wchusbserialfa130 -b57600 -D -Uflash:w:nrf_comm_master.hex:i
-avrdude -patmega328p -carduino -P/dev/tty.wchusbserialfd120 -b57600 -D -Uflash:w:nrf_comm_master.hex:i
+avrdude -patmega328p -carduino -P/dev/tty.wchusbserialfa130 -b57600 -D -Uflash:w:../bin/nrf_comm_master.hex:i
+avrdude -patmega328p -carduino -P/dev/tty.wchusbserialfd120 -b57600 -D -Uflash:w:../bin/nrf_comm_master.hex:i
+avrdude -patmega328p -carduino -P/dev/ttyUSB0 -b57600 -D -Uflash:w:../bin/nrf_comm_master.hex:i
+

--- a/spilib.c
+++ b/spilib.c
@@ -32,7 +32,8 @@ uint8_t SPIlib::transfer (uint8_t data)
     SPDR = data;
  
     //Wait until transmission complete
-    while((!SPSR) & (1<<SPIF));
+    while(!(SPSR & (1 << SPIF)))
+	;
  
     // Return received data
     return(SPDR);


### PR DESCRIPTION
Fixed bug in SPI.C which was badly interpreted while loop for waiting on end of spi transfer.
Now it works - and spriWrite() can be used every where - spiWrite2 is now not needed. Super.
And also is finally possible to use linker Relax directive.. Uff. This was few years taking bug..